### PR TITLE
Fix styling on mobile browsers

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,7 +24,9 @@
   </header>
   {#each terms as { term, kana, romaji, translation, ...extras }}
     <div class="row">
-      <TermCard {term} {kana} {romaji} {translation} {extras}/>
+      <div class="col">
+        <TermCard {term} {kana} {romaji} {translation} {extras}/>
+      </div>
     </div>
   {/each}
 </main>
@@ -74,4 +76,10 @@
 
     .header-center
       flex 0 0 50%
+
+  .col
+    justify-content center
+    flex-basis 0
+    flex-grow 1
+    max-width 100%
 </style>

--- a/src/lib/TermCard.svelte
+++ b/src/lib/TermCard.svelte
@@ -29,11 +29,12 @@
   .term-card
     border-radius 5px
     background-color var(--secondary)
-    width 50%
     margin 0 auto
+    min-width 50%
+    max-width 590px
 
   table
-    margin 5% auto
+    margin 0 auto
 
   th, td
     vertical-align text-top


### PR DESCRIPTION
Sets a min/max width and uses flex box properties so that text doesn't
overflow narrow displays (unless they're *very* narrow).

Resolves #10
